### PR TITLE
Align Raster fails using a geographic projected shapefile for clipping extent [NSPECT-55]

### DIFF
--- a/components/align_rasters/align_rasters.py
+++ b/components/align_rasters/align_rasters.py
@@ -126,8 +126,10 @@ class AlignRasters(QgsProcessingAlgorithm):
             units = QgsUnitTypes.toString(crs.mapUnits())
             if units.lower() == "degrees":
                 if buffer_distance > 1:
+                    feedback.pushWarning(
+                        "Clip buffer was set to above 1. The buffer was changed to 1 degree."
+                    )
                     buffer_distance = 1.0
-            feedback.reportError(str(buffer_distance))
 
             # Buffer
             alg_params = {

--- a/components/create_lookup_table_template/create_lookup_table_template.py
+++ b/components/create_lookup_table_template/create_lookup_table_template.py
@@ -87,10 +87,10 @@ class CreateLookupTableTemplate(QgsProcessingAlgorithm):
         return "Create Lookup Table Template"
 
     def group(self):
-        return ""
+        return "QNSPECT"
 
     def groupId(self):
-        return ""
+        return "QNSPECT"
 
     def createInstance(self):
         return CreateLookupTableTemplate()


### PR DESCRIPTION
Align Rasters module now reprojects the input vector feature to the CRS of the input raster. This prevents extent buffers that can be unexpectedly large when using a geographic CRS as a vector input.