### PR TITLE
remove check for subclass of QNSPECTAlgorithm

### DIFF
--- a/algorithms/__init__.py
+++ b/algorithms/__init__.py
@@ -1,3 +1,5 @@
+# this package should only export algorithms and nothing else
+# or else loading the algorithms into the provider will fail
 from .align_rasters.align_rasters import AlignRasters
 from .rasterize_soil.rasterize_soil import RasterizeSoil
 from .modify_land_cover.modify_land_cover_by_field import ModifyLandCover

--- a/qnspect_provider.py
+++ b/qnspect_provider.py
@@ -58,14 +58,8 @@ class QNSPECTProvider(QgsProcessingProvider):
         Loads all algorithms belonging to this provider.
         """
 
-        alg_classes = [
-            m[1]
-            for m in inspect.getmembers(algorithms, inspect.isclass)
-            if issubclass(m[1], QNSPECTAlgorithm)
-        ]
-
-        for alg_class in alg_classes:
-            self.addAlgorithm(alg_class())
+        for alg in inspect.getmembers(algorithms, inspect.isclass):
+            self.addAlgorithm(alg[1]())
 
     def id(self):
         """


### PR DESCRIPTION
This fixes `QNSPECTRunAlgorithms` not reloading when reloaded through `Plugin Reloader` plugin. 

The check for `issubclass` is removed and a comment is added to only export `QNSPECTAlgorithm` classes and subclasses from the algorithms package. The previous code was correct too but it wasn't going down well with the `Plugin Reloader` plugin for some unknown reason.